### PR TITLE
Add adlib import routines from other projects.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+priv/translations/*.mo

--- a/include/mod_adlib.hrl
+++ b/include/mod_adlib.hrl
@@ -10,5 +10,13 @@
     database :: binary(),
     extra_arguments = [] :: list( mod_adlib:api_arg() ),
     date_format = "'Y-m-d H:i:s'" :: string(),
-    timezone = <<"UTC">> :: binary()
+    timezone = <<"UTC">> :: binary(),
+    triples_fun = undefined :: fun( (mod_adlib:adlib_endpoint(), map(), z:context())
+                                 -> {ok, [ zotonic_rdf:rdf_triple() ]} | {error, term()})
+                            | undefined
 }).
+
+% Notification to collect all adlib endpoints from the site and modules.
+% Type: map
+% Return: [ mod_adlib:adlib_endpoint() ]
+-record(adlib_endpoints, {}).

--- a/priv/templates/_admin_status.tpl
+++ b/priv/templates/_admin_status.tpl
@@ -1,0 +1,22 @@
+{% wire id="adlib-import"
+        type="submit"
+        postback=`import_all`
+        delegate=`mod_adlib`
+%}
+<form method="post" action="postback" id="adlib-import">
+<div class="form-group form-inline">
+    <select class="form-control" name="endpoint">
+        {% for e in m.adlib_api.endpoints %}
+          <option value="{{ e.name|escape }}">
+              {{ e.name|escape }}  ({{ e.database|escape }})
+          </option>
+        {% endfor %}
+    </select>
+    <button class="btn btn-default" type="submit">{_ Import Adlib database _}</button>
+    <span class="help-block">
+      {_ Select an Adlib database to import all documents from. _}<br>
+      {_ The import will be running in the background, progress is reported in the _}:
+      <a href="{% url admin_log type="info" message="Adlib" %}">{_ Message log _}</a>
+    </span>
+</div>
+</form>

--- a/priv/translations/nl.po
+++ b/priv/translations/nl.po
@@ -1,0 +1,45 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# NB: Consider using poEdit <http://poedit.sourceforge.net>
+#
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2021-11-17 11:34+0100\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.0\n"
+"Last-Translator: Marc Worrell <marc@worrell.nl>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: nl\n"
+
+#: _build/default/lib/zotonic_mod_adlib/priv/templates/_admin_status.tpl:15
+msgid "Import Adlib database"
+msgstr "Adlib database importeren"
+
+#: _build/default/lib/zotonic_mod_adlib/priv/templates/_admin_status.tpl:19
+msgid "Message log"
+msgstr "Berichtenlog"
+
+#: _build/default/lib/zotonic_mod_adlib/priv/templates/_admin_status.tpl:17
+msgid "Select an Adlib database to import all documents from."
+msgstr "Selecteer een Adlib database om alle documenten te importeren."
+
+#: _build/default/lib/zotonic_mod_adlib/src/mod_adlib.erl:78
+msgid "Started import of Adlib database."
+msgstr "Begonnen met de import van de Adlib database."
+
+#: _build/default/lib/zotonic_mod_adlib/priv/templates/_admin_status.tpl:18
+msgid "The import will be running in the background, progress is reported in the"
+msgstr "De import wordt op de achtergrond uitgevoerd, de voortgang wordt gerapporteerd in de"
+
+#: _build/default/lib/zotonic_mod_adlib/src/mod_adlib.erl:80
+msgid "You are not allowed to use mod_adlib."
+msgstr "Het is niet toegestaan om mod_adlib te gebruiken."

--- a/priv/translations/template/mod_adlib.pot
+++ b/priv/translations/template/mod_adlib.pot
@@ -1,0 +1,55 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+# NB: Consider using poEdit <http://poedit.sourceforge.net>
+#
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"POT-Creation-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ./_build/default/lib/zotonic_mod_adlib/priv/templates/_admin_status.tpl:15
+msgid ""
+"Import Adlib database"
+msgstr ""
+""
+
+#: ./_build/default/lib/zotonic_mod_adlib/priv/templates/_admin_status.tpl:19
+msgid ""
+"Message log"
+msgstr ""
+""
+
+#: ./_build/default/lib/zotonic_mod_adlib/priv/templates/_admin_status.tpl:17
+msgid ""
+"Select an Adlib database to import all documents from."
+msgstr ""
+""
+
+#: ./_build/default/lib/zotonic_mod_adlib/src/mod_adlib.erl:78
+msgid ""
+"Started import of Adlib database."
+msgstr ""
+""
+
+#: ./_build/default/lib/zotonic_mod_adlib/priv/templates/_admin_status.tpl:18
+msgid ""
+"The import will be running in the background, progress is reported in the"
+msgstr ""
+""
+
+#: ./_build/default/lib/zotonic_mod_adlib/src/mod_adlib.erl:80
+msgid ""
+"You are not allowed to use mod_adlib."
+msgstr ""
+""

--- a/src/mod_adlib.erl
+++ b/src/mod_adlib.erl
@@ -88,7 +88,6 @@ observe_rsc_import_fetch(#rsc_import_fetch{ uri = <<"adlib:", _/binary>> = Uri }
             Priref = adlib_rdf:uri_to_priref(Uri),
             case triples(Endpoint, Priref, Context) of
                 {ok, Triples} ->
-                    io:format("~p~n", [ Triples ]),
                     {ok, #{
                         <<"uri">> => adlib_rdf:uri(Endpoint, Priref),
                         <<"rdf_triples">> => Triples

--- a/src/mod_adlib.erl
+++ b/src/mod_adlib.erl
@@ -25,10 +25,279 @@
 
 -type adlib_endpoint() :: #adlib_endpoint{}.
 -type adlib_result() :: {ok, term()} | {error, term()}.
+-type priref() :: binary() | integer().
 
 -type api_arg() :: {atom() | binary() | string(), atom() | binary() | string()}.
 
 -export_type([
     adlib_endpoint/0,
-    adlib_result/0
+    adlib_result/0,
+    priref/0
 ]).
+
+
+-export([
+    event/2,
+
+    observe_rsc_import_fetch/2,
+
+    fetch_record/3,
+
+    import_record/3,
+    import_all_async/2,
+    import_all/2,
+    import_since/3,
+
+    endpoints/1,
+
+    triples/3,
+
+    uri/3,
+    uri_to_endpoint/2,
+    name_to_endpoint/2
+    ]).
+
+% Internal export for async jobs and callbacks
+-export([
+    import_all_async_task/2,
+    import_all_loop/4
+    ]).
+
+
+-define(MEDIA_FETCH_TIMEOUT, 10*60*1000).
+-define(MEDIA_FETCH_MAX_LENGTH, 500*1000*1000).
+
+-include_lib("zotonic_core/include/zotonic.hrl").
+
+
+event(#submit{ message=import_all }, Context) ->
+    case z_acl:is_allowed(use, mod_adlib, Context) of
+        true ->
+            Endpoint = z_context:get_q(<<"endpoint">>, Context),
+            import_all_async(Endpoint, Context),
+            z_render:growl(?__("Started import of Adlib database.", Context), Context);
+        false ->
+            z_render:growl(?__("You are not allowed to use mod_adlib.", Context), Context)
+    end.
+
+
+%% @doc Fetch the triples of an adlib endpoint.
+observe_rsc_import_fetch(#rsc_import_fetch{ uri = <<"adlib:", _/binary>> = Uri }, Context) ->
+    case uri_to_endpoint(Uri, Context) of
+        {ok, Endpoint} ->
+            Priref = adlib_rdf:uri_to_priref(Uri),
+            triples(Endpoint, Priref, Context);
+        {error, _} ->
+            undefined
+    end;
+observe_rsc_import_fetch(#rsc_import_fetch{}, _Context) ->
+    undefined.
+
+
+%% @doc Import all documents from an Adlib endpoint in a background process.
+-spec import_all_async( Endpoint, Context ) -> ok | {error, term()}
+    when Endpoint :: adlib_endpoint() | binary(),
+         Context :: z:context().
+import_all_async(Name, Context)  when is_binary(Name) ->
+    case name_to_endpoint(Name, Context) of
+        {ok, E} -> import_all_async(E, Context);
+        {error, _} = Error -> Error
+    end;
+import_all_async(Endpoint, Context) ->
+    ?zInfo(
+        "Adlib: queue async import from endpoint '~s'",
+        [ Endpoint#adlib_endpoint.name ],
+        Context),
+    ContextAsync = z_context:prune_for_async(Context),
+    sidejob_supervisor:spawn(
+            zotonic_sidejobs,
+            {?MODULE, import_all_async_task, [ Endpoint, ContextAsync ]}),
+    ok.
+
+%% @doc Async task for importing all Adlib docs, running as a zotonic_singular_job
+%% to prevent multiple imports running at the same time.
+-spec import_all_async_task( adlib_endpoint(), z:context() ) -> any().
+import_all_async_task(Endpoint, Context) ->
+    jobs:run(zotonic_singular_job, fun() -> import_all(Endpoint, Context) end).
+
+
+-spec import_all( Endpoint, Context ) -> {ok, Count} | {error, term()}
+    when Endpoint :: adlib_endpoint() | binary(),
+         Context :: z:context(),
+         Count :: non_neg_integer().
+import_all(Endpoint, Context) ->
+    import_since(Endpoint, undefined, Context).
+
+
+-spec import_since( Endpoint, Since, Context ) -> {ok, Count} | {error, term()}
+    when Endpoint :: adlib_endpoint() | binary(),
+         Since :: m_adlib_api:date(),
+         Context :: z:context(),
+         Count :: non_neg_integer().
+import_since(Name, Since, Context) when is_binary(Name) ->
+    case name_to_endpoint(Name, Context) of
+        {ok, E} -> import_since(E, Since, Context);
+        {error, _} = Error -> Error
+    end;
+import_since(#adlib_endpoint{} = Endpoint, Since, Context) ->
+    ?zInfo(
+        "Adlib: started import from endpoint '~s' since ~p",
+        [ Endpoint#adlib_endpoint.name, Since ],
+        Context),
+    import_all_loop(m_adlib_api:fetch_since(Endpoint, Since, Context), 0, Endpoint, Context).
+
+
+import_all_loop(done, Count, _Endpoint, _Context) ->
+    {ok, Count};
+import_all_loop({error, _} = Error, _Count, _Endpoint, _Context) ->
+    Error;
+import_all_loop({ok, {Recs, Cont}}, Count, Endpoint, Context) ->
+    Count1 = lists:foldl(
+        fun(#{ <<"@attributes">> := #{ <<"priref">> := PrirefAttr } }, Acc) ->
+            Priref = z_convert:to_integer(PrirefAttr),
+            case import_record(Endpoint, Priref, Context) of
+                {ok, Id} ->
+                    ?zInfo(
+                        "Adlib: import from endpoint '~s' priref '~p' to rsc id ~p",
+                        [ Endpoint#adlib_endpoint.name, Priref, Id ],
+                        Context),
+                    Acc+1;
+                {error, Reason} ->
+                    ?zWarning(
+                        "Adlib: import from endpoint '~s' priref '~p' error ~p",
+                        [ Endpoint#adlib_endpoint.name, Priref, Reason ],
+                        Context),
+                    Acc
+            end
+        end,
+        Count,
+        Recs),
+    case Cont of
+        {next, ContFun} ->
+            ?MODULE:import_all_loop(ContFun(), Count1, Endpoint, Context);
+        done ->
+            ?zInfo(
+                "Adlib: import from endpoint '~s' finished, imported ~p documents",
+                [ Endpoint#adlib_endpoint.name, Count1 ],
+                Context),
+            {ok, Count1}
+    end.
+
+
+%% @doc Fetch a specific record from an endpoint, the Adlib JSON is returned.
+-spec fetch_record( Endpoint, Priref, Context ) -> {ok, AdlibJSON} | {error, term()}
+    when Endpoint :: mod_adlib:adlib_endpoint() | binary(),
+         Priref :: priref(),
+         Context :: z:context(),
+         AdlibJSON :: map().
+fetch_record(Name, Priref, Context) when is_binary(Name) ->
+    case name_to_endpoint(Name, Context) of
+        {ok, E} -> fetch_record(E, Priref, Context);
+        {error, _} = Error -> Error
+    end;
+fetch_record(#adlib_endpoint{} = Endpoint, Priref, Context) ->
+    m_adlib_api:fetch_record(Endpoint, Priref, Context).
+
+
+%% @doc Import a specific record from an endpoint.
+-spec import_record( Endpoint, Priref, Context ) -> {ok, RscId} | {error, term()}
+    when Endpoint :: mod_adlib:adlib_endpoint() | binary(),
+         Priref :: priref(),
+         Context :: z:context(),
+         RscId :: m_rsc:resource_id().
+import_record(Name, Priref, Context) when is_binary(Name) ->
+    case name_to_endpoint(Name, Context) of
+        {ok, E} -> import_record(E, Priref, Context);
+        {error, _} = Error -> Error
+    end;
+import_record(#adlib_endpoint{} = Endpoint, Priref, Context) ->
+    case triples(Endpoint, Priref, Context) of
+        {ok, Triples} ->
+            Options = [
+                {import_edges, 1},
+                {fetch_options, [
+                    {timeout, ?MEDIA_FETCH_TIMEOUT},
+                    {max_length, ?MEDIA_FETCH_MAX_LENGTH}
+                ]},
+                {uri_template, adlib_rdf:uri(Endpoint, <<":id">>)}
+            ],
+            case m_rsc_import:import(Triples, Options, Context) of
+                {ok, {Id, _}} -> {ok, Id};
+                {error, _} = Error -> Error
+            end;
+        {error, _} = Error ->
+            Error
+    end.
+
+-spec triples(Endpoint, Priref, Context) -> {ok, Triples} | {error, term()}
+    when Endpoint :: #adlib_endpoint{} | binary(),
+         Priref :: binary() | integer(),
+         Context :: z:context(),
+         Triples :: list( zotonic_rdf:rdf_triple() ).
+triples(Name, Priref, Context) when is_binary(Name) ->
+    case name_to_endpoint(Name, Context) of
+        {ok, E} -> triples(E, Priref, Context);
+        {error, _} = Error -> Error
+    end;
+triples(#adlib_endpoint{ triples_fun = Fun } = Endpoint, Priref, Context) ->
+    case m_adlib_api:fetch_record(Endpoint, Priref, Context) of
+        {ok, Rec} ->
+            {ok, Fun(Endpoint, Rec, Context)};
+        {error, _} = Error ->
+            Error
+    end.
+
+
+%% @doc Collect all endpoints from the site and modules.
+-spec endpoints( z:context() ) -> list( adlib_endpoint() ).
+endpoints(Context) ->
+    lists:flatten( z_notifier:map(#adlib_endpoints{}, Context) ).
+
+
+%% @doc Find the endpoint for an adlib URI.
+-spec uri_to_endpoint( Uri, Context ) -> {ok, adlib_endpoint()} | {error, unknown_endpoint}
+    when Uri :: uri_string:uri_string() | undefined,
+         Context :: z:context().
+uri_to_endpoint(undefined, _Context) ->
+    {error, unknown_endpoint};
+uri_to_endpoint(Uri, Context) ->
+    Es = endpoints(Context),
+    uri_to_endpoint_1(Uri, Es).
+
+uri_to_endpoint_1(_Uri, []) ->
+    {error, enoent};
+uri_to_endpoint_1(Uri, [ E | Es ]) ->
+    case adlib_rdf:is_matching_uri(E, Uri) of
+        true -> {ok, E};
+        false -> uri_to_endpoint_1(Uri, Es)
+    end.
+
+%% @doc Find the endpoint for an adlib endpoint name.
+-spec name_to_endpoint( Name, Context ) -> {ok, adlib_endpoint()} | {error, unknown_endpoint}
+    when Name :: binary(),
+         Context :: z:context().
+name_to_endpoint(Name, Context) ->
+    Es = endpoints(Context),
+    name_to_endpoint_1(Name, Es).
+
+name_to_endpoint_1(_Name, []) ->
+    {error, unknown_endpoint};
+name_to_endpoint_1(Name, [ #adlib_endpoint{ name = Name } = E | _ ]) ->
+    {ok, E};
+name_to_endpoint_1(Name, [ _ | Es ]) ->
+    name_to_endpoint_1(Name, Es).
+
+
+%% @doc Return the uri for an adlib priref, given the name or the endpoint.
+-spec uri( Endpoint, Priref, Context ) -> {ok, Uri} | {error, unknown_endpoint}
+    when Endpoint :: binary() | adlib_endpoint(),
+         Priref :: priref(),
+         Context :: z:context(),
+         Uri :: uri_string:uri_string().
+uri(Name, Priref, Context) when is_binary(Name) ->
+    case name_to_endpoint(Name, Context) of
+        {ok, E} -> uri(Priref, E, Context);
+        {error, _} = Error -> Error
+    end;
+uri(#adlib_endpoint{} = E, Priref, _Context) ->
+    {ok, adlib_rdf:uri(E, Priref)}.

--- a/src/models/m_adlib_api.erl
+++ b/src/models/m_adlib_api.erl
@@ -86,6 +86,21 @@ m_get([ <<"list_databases">> | Rest ], #{ payload := Payload }, Context) ->
             end;
         false ->
             {error, eacces}
+    end;
+m_get([ <<"endpoints">> | Rest ], _, Context) ->
+    case z_acl:is_allowed(use, mod_adlib, Context) of
+        true ->
+            Es = lists:map(
+                fun(E) ->
+                    #{
+                        <<"name">> => E#adlib_endpoint.name,
+                        <<"database">> => E#adlib_endpoint.database
+                    }
+                end,
+                lists:sort( mod_adlib:endpoints(Context) )),
+            {ok, {Es, Rest}};
+        false ->
+            {error, eacces}
     end.
 
 

--- a/src/support/adlib_rdf.erl
+++ b/src/support/adlib_rdf.erl
@@ -20,8 +20,8 @@
 
 -export([
     uri/2,
-    is_matching_uri/2,
-    triples/3
+    uri_to_priref/1,
+    is_matching_uri/2
     ]).
 
 
@@ -59,6 +59,12 @@ uri(Endpoint, Priref) when is_binary(Priref) ->
         $/, Priref
     ]).
 
+%% @doc Extract the priref from a valid adlib uri.
+-spec uri_to_priref( binary() ) -> integer().
+uri_to_priref(<<"adlib:", _/binary>> = Uri) ->
+    Priref = lists:last(binary:split(Uri, <<"/">>, [ global ])),
+    binary_to_integer(Priref).
+
 
 %% @doc Check if the URI belongs to the given Adlib endpoint.
 -spec is_matching_uri( Endpoint, Uri ) -> boolean()
@@ -79,15 +85,5 @@ is_matching_uri(Endpoint, <<"adlib:", Uri/binary>>) ->
         [ Host, BaseDir, Database1, _Id ] -> true;
         _ -> false
     end;
-is_matching_uri(_Endpoint, _Uri) ->
+is_matching_uri(#adlib_endpoint{}, _Uri) ->
     false.
-
-
-%% @doc Extract basic RDF triples from an Adlib record.
--spec triples( Endpoint, Record, Context ) -> {ok, list( map() )} | {error, term()}
-    when Endpoint :: mod_adlib:adlib_endpoint(),
-         Record :: map(),
-         Context :: z:context().
-triples(Endpoint, Record, Context) ->
-    {ok, []}.
-


### PR DESCRIPTION
Adds:

 - Import all documents from an adlib endpoint
 - Import a specific document from an endpoint
 - Logging of imports to /admin/log
 - Notifications to let modules add endpoints
 - admin/status option to import all documents from an endpoint
 - connection with the m_rsc_import for the import of Adlib triples
 - translations